### PR TITLE
Return undefined if target is null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,8 @@
 module.exports = (target, ...keys) => {
   let digged = target;
+  if(digged === null){
+    return undefined;
+  }
   for (const key of keys) {
     if (typeof digged === 'undefined') {
       return undefined;

--- a/test/dig_test.js
+++ b/test/dig_test.js
@@ -4,6 +4,11 @@ import assert from 'power-assert';
 describe('dig', () => {
   let target = {};
 
+  context('target is null.', () => {
+    it('get undefined', () => {
+      assert.equal(dig(null, 'unknownProp'), undefined);
+    });
+  });
   context('target is undefined.', () => {
     it('get undefined', () => {
       assert.equal(dig(undefined, 'unknownProp'), undefined);


### PR DESCRIPTION
There was an issue where if the target being passed to dig was null
then dig would break. This PR adds the guard that if the target is null
we should return undefined.