### PR TITLE
Add support for null intermediate values

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,5 @@
 module.exports = (target, ...keys) => {
   let digged = target;
-  if(digged === null){
-    return undefined;
-  }
   for (const key of keys) {
     if (typeof digged === 'undefined' || digged === null) {
       return undefined;

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ module.exports = (target, ...keys) => {
     return undefined;
   }
   for (const key of keys) {
-    if (typeof digged === 'undefined') {
+    if (typeof digged === 'undefined' || digged === null) {
       return undefined;
     }
     if (typeof key === 'function') {

--- a/test/dig_test.js
+++ b/test/dig_test.js
@@ -21,6 +21,14 @@ describe('dig', () => {
     });
   });
 
+  context('intermediate value is null', () => {
+    before(() => {
+      target = { a: { b: null}}
+    });
+    it('get undefined', () => {
+      assert.equal(dig(target, 'a', 'b', 'c'), undefined);
+    });
+  });
   context('find unknown key  on the way of digging.', () => {
     before(() => {
       target = { a: { b: { c: 'c' } } };


### PR DESCRIPTION
When you had a null value some where between the target and last key, the api would break. By returning undefined if we we ever see a null along the dig path we fix this problem.